### PR TITLE
Set keynote abstract to vertically align in the center

### DIFF
--- a/program/speakers/keynote.ejs
+++ b/program/speakers/keynote.ejs
@@ -6,7 +6,7 @@
     <div style="font-weight: bold; font-size: 1.125rem;"> <%= speaker.name %> </div>
     <div> <%= speaker.bio %> </div>
   </div>
-  <div style="display: flex; flex-direction: column; gap: 1rem; flex: 2 1 300px">
+  <div style="align-content: center; flex: 2 1 300px">
     <div style="font-weight: bold; font-size: 1.25rem;"> <%= speaker.title %> </div>
     <div> <%= speaker.abstract %> </div>
   </div>


### PR DESCRIPTION
- It's already a flex so don't need another flex
- align-content will vertically align

Still works in responsive mode in my testing